### PR TITLE
Added LADSPA plugins support

### DIFF
--- a/org.shotcut.Shotcut.yaml
+++ b/org.shotcut.Shotcut.yaml
@@ -17,7 +17,22 @@ finish-args:
   - --socket=pulseaudio
   - --device=shm # JACK
   - --env=FREI0R_PATH=/app/lib/frei0r-1
-  - --env=LADSPA_PATH=/app/lib/ladspa
+  - --env=LADSPA_PATH=/app/extensions/LadspaPlugins/ladspa:/app/lib/ladspa
+add-extensions:
+  org.freedesktop.LinuxAudio.LadspaPlugins:
+    directory: extensions/LadspaPlugins
+    version: '19.08'
+    add-ld-path: lib
+    merge-dirs: ladspa
+    subdirectories: true
+    no-autodownload: true
+  org.freedesktop.LinuxAudio.LadspaPlugins.swh:
+    directory: extensions/LadspaPlugins/swh
+    version: '19.08'
+    add-ld-path: lib
+    merge-dirs: ladspa
+    subdirectories: true
+
 cleanup:
   - /include
   - /lib/cmake
@@ -38,7 +53,7 @@ modules:
       - type: archive
         url: https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.bz2
         sha256: 685adf14bd8e9c015b78097c1dc22f2f01343756f196acdc76a678e1ae352e11
-  
+
   - name: fftw-float
     config-opts:
       - --disable-doc
@@ -64,7 +79,7 @@ modules:
       - type: archive
         url: http://www.fftw.org/fftw-3.3.8.tar.gz
         sha256: 6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303
-  
+
   - name: movit
     make-args:
       - libmovit.la
@@ -104,16 +119,7 @@ modules:
       - type: archive
         url: https://files.dyne.org/frei0r/releases/frei0r-plugins-1.7.0.tar.gz
         sha256: 1b1ff8f0f9bc23eed724e94e9a7c1d8f0244bfe33424bb4fe68e6460c088523a
-  
-  - name: swh-plugins
-    build-options:
-      cflags: -fPIC
-      ldflags: -fpic
-    sources:
-      - type: archive
-        url: https://github.com/swh/ladspa/archive/v0.4.17.tar.gz
-        sha256: d1b090feec4c5e8f9605334b47faaad72db7cc18fe91d792b9161a9e3b821ce7
-  
+
   - name: ladspa-sdk
     no-autogen: true
     subdir: src
@@ -127,7 +133,7 @@ modules:
       - type: archive
         url: https://www.ladspa.org/download/ladspa_sdk_1.15.tgz
         sha256: 4229959b09d20c88c8c86f4aa76427843011705df22d9c28b38359fd1829fded
-    
+
   - name: jack2
     buildsystem: simple
     build-commands:
@@ -240,6 +246,8 @@ modules:
       - CONFIG+=release
       - CONFIG+=force_debug_info
       - SHOTCUT_VERSION=20.04.12
+    post-install:
+      - install -d /app/extensions/LadspaPlugins
     sources:
       - type: git
         url: https://github.com/mltframework/shotcut.git


### PR DESCRIPTION
This PR is blocked by flathub/flathub#1504 that provide the swh plugins as a flatpak.

This PR add support for LADSPA plugins a flatpak.
- It defines the LADSPA Plugins extension point
- It tell to auto install swh
- it doesn't build swh anymore.

What I tested:

- Build without no swh and no extension point, missing audio filters.
- Build with the extension points added, the audio filters are there

Caveat:
I also have CMT and TAP installed and I can't get them to show up in Shotcut. (it work in other apps)

Let me know if you have questions.