### PR TITLE
Fix missing license files and more (#162)

### DIFF
--- a/org.shotcut.Shotcut.yaml
+++ b/org.shotcut.Shotcut.yaml
@@ -71,12 +71,8 @@ modules:
       - -DBUILD_SHARED_LIBS=ON
       - -DBUILD_TESTING=OFF
       - -DBUILD_APPS=OFF
-      - -DENABLE_AVX512=ON
+      - -DENABLE_AVX512=OFF
       - -DGGML_VULKAN=1
-    cleanup:
-      - '/include'
-      - '/lib/cmake'
-      - '/lib/pkgconfig'
     post-install:
       - install -Dm755 bin/whisper-cli -t /app/bin
     sources:
@@ -123,7 +119,7 @@ modules:
 
   - name: zimg
     cleanup:
-      - /share
+      - /share/doc/
     sources:
       - type: git
         url: https://github.com/sekrit-twc/zimg.git
@@ -184,6 +180,8 @@ modules:
       - INSTALL_BINARY_DIR=/app/bin
     cleanup:
       - /bin
+    post-install:
+      - install -Dm644 ../doc/COPYING -t $FLATPAK_DEST/share/licenses/$FLATPAK_ID/ladspa-sdk/
     sources:
       - type: archive
         url: https://deb.debian.org/debian/pool/main/l/ladspa-sdk/ladspa-sdk_1.17.orig.tar.gz
@@ -328,6 +326,9 @@ modules:
       - -DLibav_PREFIX=/app
       - -DCMAKE_PREFIX_PATH=/app
       - -DQT_MAJOR_VERSION=6
+    post-install:
+      - mkdir -p $FLATPAK_DEST/share/licenses/$FLATPAK_ID/glaxnimate/
+      - cp ../LICENSES/* $FLATPAK_DEST/share/licenses/$FLATPAK_ID/glaxnimate/
     sources:
       - type: git
         url: https://invent.kde.org/graphics/glaxnimate.git
@@ -352,6 +353,9 @@ modules:
     no-make-install: true
     post-install:
       - cp -v bigsh0t-*-linux/lib/frei0r-1/*.so /app/lib/frei0r-1
+      # Copy missing GPLv2 licence file form the FFMPEG
+      - mkdir -p /app/share/licenses/$FLATPAK_ID/bigsh0t/
+      - cp /app/share/licenses/org.shotcut.Shotcut/ffmpeg/COPYING.GPLv2 /app/share/licenses/$FLATPAK_ID/bigsh0t/COPYING
     sources:
       - type: git
         url: https://bitbucket.org/leo_sutic/bigsh0t.git
@@ -379,7 +383,6 @@ modules:
       - -DWITH_GTK=OFF
       - -DWITH_CAROTENE=OFF # for ARM
     cleanup:
-      - /lib/cmake
       - /bin/*
     sources:
       - type: git


### PR DESCRIPTION
* Use top-level cleanup commands
* Fix missing license file: zimg
* Fix missing license file: ladspa-sdk
* Fix missing license file: glaxnimate
* Fix missing license file: bigshOt
